### PR TITLE
Bump version to 0.5.1 and update DocumentReference

### DIFF
--- a/examples/DocumentReference-AshdodDocumentReferenceExample.json
+++ b/examples/DocumentReference-AshdodDocumentReferenceExample.json
@@ -5,7 +5,7 @@
     "security": [
       {
         "system": "http://fhir.health.gov.il/cs/il-hdp-information-buckets",
-        "code": "סיכומים",
+        "code": "clinicalNotes",
         "display": "סיכומים"
       }
     ],

--- a/input/fsh/ConformanceMetadata.fsh
+++ b/input/fsh/ConformanceMetadata.fsh
@@ -1,6 +1,6 @@
 RuleSet: ConformanceMetadata
-* ^version = "0.5.0"
+* ^version = "0.5.1"
 * ^publisher = "Assuta Ashdod Medical Center"
-* ^date = "2026-05-07"
+* ^date = "2026-05-24"
 * ^contact[0].telecom[0].system = #email
 * ^contact[0].telecom[0].value = "contact@example.org"

--- a/input/fsh/DocumentReference.fsh
+++ b/input/fsh/DocumentReference.fsh
@@ -14,7 +14,7 @@ Description: "Asuta Ashdod Document Reference"
 // masterIdentifier
 * masterIdentifier 1..1
 * masterIdentifier.system 1..1
-* masterIdentifier.system = "http://fhir.ashmc.co.il/identifier/document-router-versioned-message-id" (exactly)
+// * masterIdentifier.system = "http://fhir.ashmc.co.il/identifier/document-router-versioned-message-id" (exactly)
 * masterIdentifier.value 1..1
 
 // docStatus
@@ -25,7 +25,7 @@ Description: "Asuta Ashdod Document Reference"
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.rules = #open
-* identifier contains router-message-id 1..1
+* identifier contains router-message-id 0..1
 * identifier[router-message-id].system 1..1
 * identifier[router-message-id].system = "http://fhir.ashmc.co.il/identifier/document-router-message-id" (exactly)
 * identifier[router-message-id].value 1..1
@@ -34,7 +34,7 @@ Description: "Asuta Ashdod Document Reference"
 * type.coding ^slicing.discriminator.type = #value
 * type.coding ^slicing.discriminator.path = "system"
 * type.coding ^slicing.rules = #open
-* type.coding contains msg-sub-type 1..1 and loinc 1..1
+* type.coding contains msg-sub-type 0..1 and loinc 1..1
 
 * type.coding[msg-sub-type].system 1..1
 * type.coding[msg-sub-type].system = "http://fhir.ashmc.co.il/identifier/document-message-sub-type" (exactly)

--- a/input/fsh/Extensions/Ext-document-reference-file-location.fsh
+++ b/input/fsh/Extensions/Ext-document-reference-file-location.fsh
@@ -1,8 +1,3 @@
-Invariant: ext-docref-file-loc-1
-Description: "Exactly one of `valueString` or `valueUrl` SHALL be present"
-Expression: "valueString.exists() xor valueUrl.exists()"
-Severity: #error
-
 Extension: DocumentReferenceFileLocation
 Id: ext-document-reference-file-location
 Title: "Ext: Document Reference File Location"
@@ -16,8 +11,6 @@ Description: "Indicates the physical or logical file location of the binary cont
 * ^context[0].expression = "DocumentReference.content.attachment"
 
 * . ^comment = "This extension is intentionally not included in the DocumentReference profile, as it does not represent part of the logical FHIR resource. It is used solely for internal processing within a facade or integration layer to resolve the physical file location and populate DocumentReference.content.attachment.data. The extension is removed prior to returning the resource to clients and therefore is not part of the exposed or persisted resource definition."
-
-* obeys ext-docref-file-loc-1
 
 * value[x] only string or url
 * valueString 0..1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "il.fhir.r4.ashmc",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "il.fhir.r4.ashmc",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "dependencies": {
                 "adm-zip": "^0.5.14",
                 "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "il.fhir.r4.ashmc",
-    "version":  "0.5.0",
+    "version":  "0.5.1",
     "description":  "FHIR Profiles and Implementation Guide for Assuta Ashdod Medical Center",
     "type":  "module",
     "scripts":  {

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: ASHMC
 title: Assuta Ashdod Medical Center Profiles
 description: FHIR Profiles and Implementation Guide for Assuta Ashdod Medical Center
 status: draft # draft | active | retired | unknown
-version: 0.5.0
+version: 0.5.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2024+
 releaseLabel: draft # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
This pull request updates the Assuta Ashdod FHIR Implementation Guide to version 0.5.1, relaxing several cardinality constraints in the `DocumentReference` profile and removing an invariant from the `DocumentReferenceFileLocation` extension. The changes also update metadata and example terminology for improved consistency.

**Profile and Extension Constraint Updates:**

* Relaxed the cardinality of `identifier[router-message-id]` from required (`1..1`) to optional (`0..1`) in the `DocumentReference` profile, making this identifier optional.
* Relaxed the cardinality of `type.coding[msg-sub-type]` from required (`1..1`) to optional (`0..1`) in the `DocumentReference` profile, making the message sub-type optional.
* Commented out the fixed value constraint for `masterIdentifier.system` in the `DocumentReference` profile, removing the requirement for a specific system value.
* Removed the invariant (`ext-docref-file-loc-1`) enforcing that exactly one of `valueString` or `valueUrl` must be present in the `DocumentReferenceFileLocation` extension, and deleted the corresponding `obeys` rule. [[1]](diffhunk://#diff-2d58fde2af11fbe088ac10923a0a6a9ded268f82de6d83031241267046873700L1-L5) [[2]](diffhunk://#diff-2d58fde2af11fbe088ac10923a0a6a9ded268f82de6d83031241267046873700L20-L21)

**Terminology and Metadata Updates:**

* Changed the code value in the example `DocumentReference-AshdodDocumentReferenceExample.json` from Hebrew ("סיכומים") to the English term "clinicalNotes" for consistency with the code system.
* Updated version numbers and publication date in `ConformanceMetadata.fsh`, `package.json`, and `sushi-config.yaml` to reflect the new release (0.5.1). [[1]](diffhunk://#diff-c802b18752c68c1f276d8d1588a0b0eaf31780b9cf44c36c3cdfbdf209c07fa1L2-R4) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L12-R12)